### PR TITLE
Improve docs generation

### DIFF
--- a/bin/docs
+++ b/bin/docs
@@ -24,14 +24,35 @@ function writeFile(filename, data) {
   fs.writeFileSync(filename, data);
 }
 
+function sortByClass(docs) {
+  let classes = docs.filter((d) => d.kind === 'class');
+  let byLongname = (a, b) => a.longname > b.longname ? 1 : -1;
+
+  let groupedByClass = classes.map((c) => {
+    return [c].concat(
+      docs.filter((d) => d.memberof == c.longname && d.kind === 'member').sort(byLongname),
+      docs.filter((d) => d.memberof == c.longname && d.kind !== 'member').sort(byLongname)
+    );
+  });
+
+  let ungrouped = docs.filter((d) => !d.memberof && d.kind === 'function').sort(byLongname);
+
+  let sorted = groupedByClass.concat(ungrouped).reduce((acc, val) => acc.concat(val), []);
+
+  return sorted;
+}
+
 function generateDocs() {
   let docs = jsdoc.explainSync({
-    files: path.join(cwd, `${input}/*.js`)
+    files: path.join(cwd, `${input}/**/*.js`),
+    configure: path.join(__dirname, '../jsdoc.config.json')
   }).filter((doc) => {
     // don't document undocumented docs...
     return !doc.undocumented &&
       // or private docs that don't belong to anything
-      (doc.access !== 'private' || !!doc.memberof);
+      (doc.access !== 'private' || !!doc.memberof) &&
+      // removes `package:undefined`
+      (doc.kind !== 'package');
   }).map((doc) => {
     // remove cwd from file paths
     if (doc.meta && doc.meta.path) {
@@ -40,6 +61,8 @@ function generateDocs() {
 
     return doc;
   });
+
+  docs = sortByClass(docs);
 
   writeFile(
     path.join(cwd, output),

--- a/bin/docs
+++ b/bin/docs
@@ -24,22 +24,21 @@ function writeFile(filename, data) {
   fs.writeFileSync(filename, data);
 }
 
-function sortByClass(docs) {
-  let classes = docs.filter((d) => d.kind === 'class');
-  let byLongname = (a, b) => a.longname > b.longname ? 1 : -1;
+function compareDocs(a, b) {
+  let compareKey = (key, value) => {
+    if (a[key] !== value && b[key] === value) {
+      return 1;
+    } else if (a[key] === value && b[key] !== value) {
+      return -1;
+    } else {
+      return 0;
+    }
+  };
 
-  let groupedByClass = classes.map((c) => {
-    return [c].concat(
-      docs.filter((d) => d.memberof == c.longname && d.kind === 'member').sort(byLongname),
-      docs.filter((d) => d.memberof == c.longname && d.kind !== 'member').sort(byLongname)
-    );
-  });
-
-  let ungrouped = docs.filter((d) => !d.memberof && d.kind === 'function').sort(byLongname);
-
-  let sorted = groupedByClass.concat(ungrouped).reduce((acc, val) => acc.concat(val), []);
-
-  return sorted;
+  return compareKey('kind', 'class') ||
+    compareKey('scope', 'static') ||
+    compareKey('kind', 'member') ||
+    (a.longname > b.longname ? 1 : -1);
 }
 
 function generateDocs() {
@@ -60,9 +59,7 @@ function generateDocs() {
     }
 
     return doc;
-  });
-
-  docs = sortByClass(docs);
+  }).sort(compareDocs);
 
   writeFile(
     path.join(cwd, output),

--- a/jsdoc.config.json
+++ b/jsdoc.config.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["node_modules/jsdoc-escape-at"]
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bigtest-tag-version": "./bin/tag-version"
   },
   "dependencies": {
-    "jsdoc-api": "^4.0.3"
+    "jsdoc-api": "^4.0.3",
+    "jsdoc-escape-at": "^1.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,6 +123,10 @@ jsdoc-api@^4.0.3:
     temp-path "^1.0.0"
     walk-back "^3.0.0"
 
+jsdoc-escape-at@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsdoc-escape-at/-/jsdoc-escape-at-1.0.1.tgz#a1264683a32f3e03a589c85d6e92769718c7ab90"
+
 jsdoc@~3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"


### PR DESCRIPTION
There were a couple things done in this PR. We added: 
- a jsdoc plugin to allow escaping the `@` symbol that is used for decorators
- removed `package:undefined` from the doc results 
- sorted the docs from property to method.

I know @wwilsman is probably going to want to clean up the sort we're doing. 

![image](https://user-images.githubusercontent.com/2072894/39654161-619de3de-4fb9-11e8-932f-5fba1683538d.png)
